### PR TITLE
Changes debug print to use standard pything logging

### DIFF
--- a/cellulariot/cellulariot.py
+++ b/cellulariot/cellulariot.py
@@ -6,6 +6,7 @@
   Created by Yasin Kaya (selengalp), August 28, 2018.
 '''
 
+import logging
 import time
 import serial
 import RPi.GPIO as GPIO
@@ -16,6 +17,7 @@ from .MMA8452Q import MMA8452Q
 # global variables
 TIMEOUT = 3 # seconds
 ser = serial.Serial()
+logger = logging.getLogger(__name__)
 
 ###########################################
 ### Private Methods #######################
@@ -23,7 +25,7 @@ ser = serial.Serial()
 
 # Function for printing debug message 
 def debug_print(message):
-	print(message)
+	logger.debug(message)
 
 # Function for getting time as miliseconds
 def millis():

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='sixfab_cellulariot',
-    version='1.2.0',
+    version='1.2.1',
     author='Yasin Kaya',
     author_email='yasinkaya.121@gmail.com',
     description='sixfab linux libraries',


### PR DESCRIPTION
Changing the debug log to use standard python logging allow users to configure what should be printed or not.

This allows people to control the logging of the debug comms easily with

```
import logging
logiot = logging.getLogger('cellulariot.cellulariot')
logiot.setLevel('INFO')
```

Or even redirect the logging to a file without creating console output.